### PR TITLE
Fix: Add global CSS rule to prevent white text on white background

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -24,3 +24,14 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+/* Attempt to fix white-on-white text issues where text-white is used on a white background */
+[style*="--background:white"] [class*="text-white"],
+[style*="--background:#fff"] [class*="text-white"],
+[style*="--background:#ffffff"] [class*="text-white"],
+.bg-white [class*="text-white"],
+body[style*="--background:white"] [class*="text-white"],
+body[style*="--background:#fff"] [class*="text-white"],
+body[style*="--background:#ffffff"] [class*="text-white"] {
+  color: var(--foreground) !important;
+}


### PR DESCRIPTION
The issue report indicated that some text (related to "Conversations") was appearing as white on a white background.

I could not locate the specific text or elements causing this problem after searching the codebase.

As a preventative measure, this commit adds a global CSS rule to `app/globals.css`. This rule attempts to force the standard foreground color on elements that have white text (e.g., via a `text-white` class) and are on a white background. This is a broad fix intended to catch the reported issue and prevent similar occurrences.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved text visibility by ensuring white text automatically switches to a contrasting color when placed on white backgrounds, preventing white-on-white readability issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->